### PR TITLE
 fix nonce and gaslimit display issue

### DIFF
--- a/src/lib/pb_parser.c
+++ b/src/lib/pb_parser.c
@@ -17,7 +17,6 @@
 #include "string.h"
 #include "stdlib.h"
 #include "stdint.h"
-#include "inttypes.h"
 
 #include "pb_parser.h"
 #include "tx_parser.h"
@@ -47,6 +46,46 @@ decode_varint(const uint8_t *buf, uint8_t *skip_bytes, uint8_t max_len) {
 	(*skip_bytes) = idx+1;
 	return result;
 }
+
+char *
+u642str(uint64_t num, char *str, size_t max_len) {
+
+    char temp;
+    int last = 0;
+    char *start = str, *end = str;
+
+    if (0 == num) {
+        str[0] = '0';
+        str[1] = 0;
+        return str;
+    }
+
+    while (num != 0) {
+        if (end - start < max_len - 1) {
+            last = num % 10;
+            *end = last + '0';
+            num /= 10;
+            end++;
+        }
+        else {
+            /* buffer too short */
+            return NULL;
+        }
+    }
+
+    /* string ends with \0 */
+    *end = 0;
+
+    while (start < --end) {
+        temp = *start;
+        *start = *end;
+        *end = temp;
+        start++;
+    }
+
+    return str;
+}
+
 int
 decode_tx_pb(const uint8_t *pb_data, uint8_t *skip_bytes_out,uint32_t len, uint32_t *totalfields, int queryid)
 {
@@ -279,8 +318,7 @@ decode_pb(const uint8_t *pb_data, uint32_t len, uint32_t *totalfields_out, int q
                 if (curid == queryid) {
                     snprintf(tx_ctx.query.out_key, tx_ctx.query.out_key_len,
                          "Nonce");
-                    snprintf(tx_ctx.query.out_val, tx_ctx.query.out_val_len,
-                         "%" PRIu64"", nonce);
+                    u642str(nonce, tx_ctx.query.out_val, tx_ctx.query.out_val_len);
                 }
                 curid++;
                 break;
@@ -297,8 +335,7 @@ decode_pb(const uint8_t *pb_data, uint32_t len, uint32_t *totalfields_out, int q
                 if (curid == queryid) {
                     snprintf(tx_ctx.query.out_key, tx_ctx.query.out_key_len,
                          "Gas Limit");
-                    snprintf(tx_ctx.query.out_val, tx_ctx.query.out_val_len,
-                         "%" PRIu64"", gas_limit);
+                    u642str(gas_limit, tx_ctx.query.out_val, tx_ctx.query.out_val_len);
                 }
                 curid++;
                 break;

--- a/src/lib/pb_parser.c
+++ b/src/lib/pb_parser.c
@@ -17,6 +17,7 @@
 #include "string.h"
 #include "stdlib.h"
 #include "stdint.h"
+#include "inttypes.h"
 
 #include "pb_parser.h"
 #include "tx_parser.h"
@@ -279,7 +280,7 @@ decode_pb(const uint8_t *pb_data, uint32_t len, uint32_t *totalfields_out, int q
                     snprintf(tx_ctx.query.out_key, tx_ctx.query.out_key_len,
                          "Nonce");
                     snprintf(tx_ctx.query.out_val, tx_ctx.query.out_val_len,
-                         "%d", nonce);
+                         "%" PRIu64"", nonce);
                 }
                 curid++;
                 break;
@@ -297,7 +298,7 @@ decode_pb(const uint8_t *pb_data, uint32_t len, uint32_t *totalfields_out, int q
                     snprintf(tx_ctx.query.out_key, tx_ctx.query.out_key_len,
                          "Gas Limit");
                     snprintf(tx_ctx.query.out_val, tx_ctx.query.out_val_len,
-                         "%d", gas_limit);
+                         "%" PRIu64"", gas_limit);
                 }
                 curid++;
                 break;


### PR DESCRIPTION
directly convert uint64_t to string save to tx_ctx.query.out_val